### PR TITLE
Logos view now also available for addons and games

### DIFF
--- a/1080i/IncludesViews.xml
+++ b/1080i/IncludesViews.xml
@@ -87,7 +87,7 @@
             <include condition="!Skin.HasSetting(SkinHelper.View.Disabled.524) + Window.IsActive(MyVideoNav.xml)">View_524_Showcase</include>
             <include condition="!Skin.HasSetting(SkinHelper.View.Disabled.56) + Window.IsActive(MyVideoNav.xml)">View_56_BannerPlex</include>
             <include condition="!Skin.HasSetting(SkinHelper.View.Disabled.55) + Window.IsActive(MyVideoNav.xml)">View_55_BannerList</include>
-            <include condition="!Skin.HasSetting(SkinHelper.View.Disabled.503) + Window.IsActive(MyVideoNav.xml)">View_503_Logos</include>
+            <include condition="!Skin.HasSetting(SkinHelper.View.Disabled.503) + [Window.IsActive(MyVideoNav.xml) | Window.IsActive(programs) | Window.IsActive(games)]">View_503_Logos</include>
             <include condition="!Skin.HasSetting(SkinHelper.View.Disabled.523)">View_523_Netflix</include>
 			<include condition="!Skin.HasSetting(SkinHelper.View.Disabled.525) + [Window.IsActive(MyVideoNav.xml) | Window.IsActive(programs)]">View_525_Netflix_Landscape</include>
 			<include condition="!Skin.HasSetting(SkinHelper.View.Disabled.526) + [Window.IsActive(MyVideoNav.xml) | Window.IsActive(programs)]">View_526_Wide_Netflix</include>

--- a/1080i/View_503_Logos.xml
+++ b/1080i/View_503_Logos.xml
@@ -7,6 +7,7 @@
 		<value condition="!String.IsEmpty(ListItem.Art(clearlogo))">$INFO[ListItem.Art(clearlogo)]</value>
 		<value condition="!String.IsEmpty(ListItem.Art(landscape))">$INFO[ListItem.Art(landscape)]</value>
 		<value condition="!String.IsEmpty(ListItem.Thumb)">$INFO[ListItem.Thumb]</value>
+		<value condition="!String.IsEmpty(ListItem.Icon)">$INFO[ListItem.Icon]</value>
 		<value condition="String.IsEqual(ListItem.Label,..)">DefaultFolderBack.png</value>
 		<value>DefaultMovies.png</value>
 	</variable>
@@ -35,7 +36,7 @@
 					<onright>503</onright>
 					<onup>9000</onup>
 					<ondown condition="Skin.HasSetting(EnableQuickJump)">7000</ondown>
-                <ondown condition="!Skin.HasSetting(EnableQuickJump)">60</ondown>
+                	<ondown condition="!Skin.HasSetting(EnableQuickJump)">60</ondown>
 					<focusposition>1</focusposition>
 					<pagecontrol>60</pagecontrol>
 					<preloaditems>2</preloaditems>

--- a/extras/views.xml
+++ b/extras/views.xml
@@ -31,10 +31,10 @@
     <view id="Extended" value="506" languageid="31433" type="all" />
     <view id="Cards" value="517" languageid="31658" type="all" />
     <view id="Wide" value="518" languageid="31659" type="all" />
-	<view id="Logos" value="503" languageid="31461" type="movies,setmovies,tvshows,musicvideos" />
+	<view id="Logos" value="503" languageid="31461" type="movies,setmovies,tvshows,musicvideos,addons,files,games" />
 	<view id="FanArt" value="507" languageid="31434" type="movies,setmovies,tvshows,musicvideos,seasons,sets,pictures" />
 	<view id="Netflix" value="523" languageid="31018" type="!episodes,all" />
 	<view id="Netflix Landscape" value="525" languageid="31918" type="all" />
-	<view id="Wide Netflix" value="526" languageid="31827" type="seasons" />
+	<view id="Wide Netflix" value="526" languageid="31827" type="seasons,addons" />
 	<view id="TSE" value="527" languageid="31901" type="tvshows" />	
 </views>


### PR DESCRIPTION
Made logos view now also available for addons and games views. Added another image fallback to ListItem.Icon to have wider image/art support.
Example of usage: https://imgur.com/a/IFlTI3S