### PR TITLE
PVR and media flag changes

### DIFF
--- a/1080i/IncludesVariables.xml
+++ b/1080i/IncludesVariables.xml
@@ -589,8 +589,10 @@
     </variable>
     
     <variable name="ListTitlePVR">
+	<value condition="!String.IsEmpty(ListItem.EpisodeName)">$INFO[ListItem.EpisodeName]</value>
         <value condition="!String.IsEmpty(ListItem.Title)">$INFO[ListItem.Title]</value>
         <value condition="!String.IsEmpty(ListItem.Label)">$INFO[ListItem.Label]</value>
+	<value condition="!String.IsEmpty(Container(510).ListItem.EpisodeName)">$INFO[Container(510).ListItem.EpisodeName]</value>
         <value condition="!String.IsEmpty(Container(510).ListItem.Title)">$INFO[Container(510).ListItem.Title]</value>
         <value condition="!String.IsEmpty(Container(510).ListItem.Label)">$INFO[Container(510).ListItem.Label]</value>
     </variable>


### PR DESCRIPTION
Using the Tvheadend PVR plugin, recorded shows were not showing the episode name in the list, just the show name. The 4k media flag image was different than other resolutions and did not display properly. This pull request fixes both of those issues.